### PR TITLE
auth: correctly recognize Authorization header

### DIFF
--- a/src/Middleware/AuthorizationMiddleware.php
+++ b/src/Middleware/AuthorizationMiddleware.php
@@ -39,8 +39,7 @@ class AuthorizationMiddleware
 			return $next($request);
 		}
 
-		/** @var string|array<mixed> $headerToken */
-		$headerToken = $request->getHeader('Authorization');
+		$headerToken = $request->getHeader('Authorization')[0] ?? null;
 
 		if (is_string($headerToken) === false) {
 			return ErrorResponse::create()->withErrorCode(401)->withMessage('Unauthorized');


### PR DESCRIPTION
`getHeader` always returns array of headers since there can be multiple ones. Now it doesn't work correctly because `is_string` is never true for array.

This change fixes that by using the first `Authorization` header if it exists.